### PR TITLE
Default `repo-token` input to `GITHUB_TOKEN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bumped `@actions/core` from 1.2.6 to 1.2.7
 - Bumped `@actions/io` from 1.0.2 to 1.1.0
+- Updated the `repo-token` input to be optional and defaulted it to `GITHUB_TOKEN`.
 
 ## Version 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ jobs:
 
       - name: Run dotnet format
         uses: xt0rted/dotnet-format@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 Running on `pull_request`.
@@ -51,7 +49,6 @@ jobs:
       - name: Run dotnet format
         uses: xt0rted/dotnet-format@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           only-changed-files: "true"
 ```
 
@@ -74,7 +71,6 @@ jobs:
         uses: xt0rted/slash-command-action@v1
         continue-on-error: true
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           command: dotnet
           reaction-type: "eyes"
 
@@ -101,7 +97,6 @@ jobs:
         id: format
         uses: xt0rted/dotnet-format@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           action: "fix"
           only-changed-files: true
 
@@ -128,13 +123,13 @@ jobs:
 
 Name | Allowed values | Description
 -- | -- | --
-`repo-token` | `GITHUB_TOKEN` or a custom value | The token used to call the GitHub api.
+`repo-token` | `GITHUB_TOKEN` (default) or PAT | `GITHUB_TOKEN` token or a repo scoped PAT.
 
 ### Optional
 
 Name | Allowed values | Description
 -- | -- | --
-`action` | `check` (default), `fix` | The primary action dotnet-format should perform.
+`action` | `check` (default), `fix` | Primary action `dotnet-format` should perform.
 `only-changed-files` | `true`, `false` (default) | Only changed files in the current pull request should be formatted.
 `fail-fast` | `true` (default), `false` | The job should fail if there's a formatting error. Only used with the `check` action.
 

--- a/action.yml
+++ b/action.yml
@@ -10,11 +10,12 @@ branding:
 
 inputs:
   repo-token:
-    description: "The GITHUB_TOKEN secret"
+    description: "GITHUB_TOKEN token or a repo scoped PAT"
     required: true
+    default: ${{ github.token }}
 
   action:
-    description: "The primary action dotnet-format should perform (check for errors or apply fixes)"
+    description: "Primary action dotnet-format should perform (check for errors or apply fixes)"
     required: false
     default: "check"
 


### PR DESCRIPTION
This update makes it so the `repo-token` input value is optional and defaults it to `GITHUB_TOKEN` which is the most common value to be used. This is a backwards compatible change.