### PR TITLE
More easily support new `dotnet-format` versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bumped `@actions/core` from 1.2.6 to 1.2.7
 - Bumped `@actions/io` from 1.0.2 to 1.1.0
 - Updated the `repo-token` input to be optional and defaulted it to `GITHUB_TOKEN`. If you're already using this value, or not using the `only-changed-files` option, you can remove this setting from your workflow.
+- Updated the output target from `es6` to `es2019`
 
 ## Version 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bumped `@actions/io` from 1.0.2 to 1.1.0
 - Updated the `repo-token` input to be optional and defaulted it to `GITHUB_TOKEN`. If you're already using this value, or not using the `only-changed-files` option, you can remove this setting from your workflow.
 - Updated the output target from `es6` to `es2019`
+- Added a new `version` input to allow picking the cli version of `dotnet-format` to use. Currently this defaults to `3` and is the only version supported. A future update will add support for versions 4 and 5.
 
 ## Version 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ jobs:
 Name | Allowed values | Description
 -- | -- | --
 `repo-token` | `GITHUB_TOKEN` (default) or PAT | `GITHUB_TOKEN` token or a repo scoped PAT.
+`version` | `3` (default) | Version of `dotnet-format` to use.
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -161,12 +161,12 @@ Name | Allowed values | Description
 -- | -- | --
 `repo-token` | `GITHUB_TOKEN` (default) or PAT | `GITHUB_TOKEN` token or a repo scoped PAT.
 `version` | `3` (default) | Version of `dotnet-format` to use.
+`action` | `check` (default), `fix` | Primary action `dotnet-format` should perform.
 
 ### Optional
 
 Name | Allowed values | Description
 -- | -- | --
-`action` | `check` (default), `fix` | Primary action `dotnet-format` should perform.
 `only-changed-files` | `true`, `false` (default) | Only changed files in the current pull request should be formatted.
 `fail-fast` | `true` (default), `false` | The job should fail if there's a formatting error. Only used with the `check` action.
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
 
   action:
     description: "Primary action dotnet-format should perform (check for errors or apply fixes)"
-    required: false
+    required: true
     default: "check"
 
   only-changed-files:

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,11 @@ inputs:
     required: true
     default: ${{ github.token }}
 
+  version:
+    description: "Version of dotnet-format to use"
+    required: true
+    default: "3"
+
   action:
     description: "Primary action dotnet-format should perform (check for errors or apply fixes)"
     required: false

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -4,12 +4,16 @@ import {
 } from "@actions/core";
 
 import { format } from "./dotnet";
+import { checkVersion } from "./version";
 
 export async function check(): Promise<void> {
   const onlyChangedFiles = getInput("only-changed-files") === "true";
   const failFast = getInput("fail-fast") === "true";
+  const version = getInput("version", { required: true });
 
-  const result = await format({
+  const dotnetFormatVersion = checkVersion(version);
+
+  const result = await format(dotnetFormatVersion)({
     dryRun: true,
     onlyChangedFiles,
   });
@@ -24,8 +28,11 @@ export async function check(): Promise<void> {
 
 export async function fix(): Promise<void> {
   const onlyChangedFiles = getInput("only-changed-files") === "true";
+  const version = getInput("version", { required: true });
 
-  const result = await format({
+  const dotnetFormatVersion = checkVersion(version);
+
+  const result = await format(dotnetFormatVersion)({
     dryRun: false,
     onlyChangedFiles,
   });

--- a/src/dotnet.ts
+++ b/src/dotnet.ts
@@ -64,7 +64,7 @@ async function formatVersion3(options: FormatOptions): Promise<boolean> {
 }
 
 export function format(version: DotNetFormatVersion): FormatFunction {
-  switch (version) {
+  switch (version || "") {
     case "3":
       return formatVersion3;
 

--- a/src/dotnet.ts
+++ b/src/dotnet.ts
@@ -11,6 +11,10 @@ import { getPullRequestFiles } from "./files";
 
 import type { ExecOptions } from "@actions/exec/lib/interfaces";
 
+import type { DotNetFormatVersion } from "./version";
+
+export type FormatFunction = (options: FormatOptions) => Promise<boolean>;
+
 export interface FormatOptions {
   dryRun: boolean;
   onlyChangedFiles: boolean;
@@ -30,7 +34,7 @@ function formatOnlyChangedFiles(onlyChangedFiles: boolean): boolean {
   return false;
 }
 
-export async function format(options: FormatOptions): Promise<boolean> {
+async function formatVersion3(options: FormatOptions): Promise<boolean> {
   const execOptions: ExecOptions = { ignoreReturnCode: true };
 
   const dotnetFormatOptions = ["format", "--check"];
@@ -57,4 +61,14 @@ export async function format(options: FormatOptions): Promise<boolean> {
   const dotnetResult = await exec(`"${dotnetPath}"`, dotnetFormatOptions, execOptions);
 
   return !!dotnetResult;
+}
+
+export function format(version: DotNetFormatVersion): FormatFunction {
+  switch (version) {
+    case "3":
+      return formatVersion3;
+
+    default:
+      throw Error(`dotnet-format version "${version}" is unsupported`);
+  }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,3 @@
-export const DEFAULT_VERSION: DotNetFormatVersion = "3";
-
 export type DotNetFormatVersion =
   | "3"
 ;
@@ -9,9 +7,6 @@ const supportedVersions: DotNetFormatVersion[] = [
 ];
 
 export function checkVersion(version: string): DotNetFormatVersion {
-  // if no version is supplied default to 3 since that was the first supported version
-  if (!version) return DEFAULT_VERSION;
-
   for (let i = 0; i < supportedVersions.length; i++) {
     const ver = supportedVersions[i];
     if (ver === version) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,23 @@
+export const DEFAULT_VERSION: DotNetFormatVersion = "3";
+
+export type DotNetFormatVersion =
+  | "3"
+;
+
+const supportedVersions: DotNetFormatVersion[] = [
+  "3",
+];
+
+export function checkVersion(version: string): DotNetFormatVersion {
+  // if no version is supplied default to 3 since that was the first supported version
+  if (!version) return DEFAULT_VERSION;
+
+  for (let i = 0; i < supportedVersions.length; i++) {
+    const ver = supportedVersions[i];
+    if (ver === version) {
+      return version;
+    }
+  }
+
+  throw Error(`dotnet-format version "${version}" is unsupported`);
+}


### PR DESCRIPTION
This adds a new `version` option so you can pick between the `dotnet-format` versions the action supports. For now only `3` is supported with `4` & `5` being added in their own PRs.